### PR TITLE
added load resource pack with offset feature

### DIFF
--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -129,12 +129,13 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 		return false;
 	}
 
-    f->seek(p_offset);
+	f->seek(p_offset);
 
 	uint32_t magic = f->get_32();
 
 	if (magic != PACK_HEADER_MAGIC && p_offset == 0) {
 		//maybe at the end.... self contained exe
+		// loading with offset feature not supported for self contained exe files
 		f->seek_end();
 		f->seek(f->get_position() - 4);
 		magic = f->get_32();

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -34,7 +34,7 @@
 
 #include <stdio.h>
 
-Error PackedData::add_pack(const String &p_path, bool p_replace_files, int p_offset) {
+Error PackedData::add_pack(const String &p_path, bool p_replace_files, size_t p_offset) {
 	for (int i = 0; i < sources.size(); i++) {
 		if (sources[i]->try_open_pack(p_path, p_replace_files, p_offset)) {
 			return OK;
@@ -123,7 +123,7 @@ PackedData::~PackedData() {
 
 //////////////////////////////////////////////////////////////////
 
-bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, int p_offset) {
+bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	if (!f) {
 		return false;

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -34,9 +34,9 @@
 
 #include <stdio.h>
 
-Error PackedData::add_pack(const String &p_path, bool p_replace_files) {
+Error PackedData::add_pack(const String &p_path, bool p_replace_files, int p_offset) {
 	for (int i = 0; i < sources.size(); i++) {
-		if (sources[i]->try_open_pack(p_path, p_replace_files)) {
+		if (sources[i]->try_open_pack(p_path, p_replace_files, p_offset)) {
 			return OK;
 		}
 	}
@@ -123,15 +123,17 @@ PackedData::~PackedData() {
 
 //////////////////////////////////////////////////////////////////
 
-bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files) {
+bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, int p_offset) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	if (!f) {
 		return false;
 	}
 
+    f->seek(p_offset);
+
 	uint32_t magic = f->get_32();
 
-	if (magic != PACK_HEADER_MAGIC) {
+	if (magic != PACK_HEADER_MAGIC && p_offset == 0) {
 		//maybe at the end.... self contained exe
 		f->seek_end();
 		f->seek(f->get_position() - 4);
@@ -191,7 +193,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files) 
 		uint64_t size = f->get_64();
 		uint8_t md5[16];
 		f->get_buffer(md5, 16);
-		PackedData::get_singleton()->add_path(p_path, path, ofs, size, md5, this, p_replace_files);
+		PackedData::get_singleton()->add_path(p_path, path, ofs + p_offset, size, md5, this, p_replace_files);
 	}
 
 	f->close();

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -108,7 +108,7 @@ public:
 	_FORCE_INLINE_ bool is_disabled() const { return disabled; }
 
 	static PackedData *get_singleton() { return singleton; }
-	Error add_pack(const String &p_path, bool p_replace_files, int p_offset);
+	Error add_pack(const String &p_path, bool p_replace_files, size_t p_offset);
 
 	_FORCE_INLINE_ FileAccess *try_open_path(const String &p_path);
 	_FORCE_INLINE_ bool has_path(const String &p_path);
@@ -119,14 +119,14 @@ public:
 
 class PackSource {
 public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, int p_offset) = 0;
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset) = 0;
 	virtual FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file) = 0;
 	virtual ~PackSource() {}
 };
 
 class PackedSourcePCK : public PackSource {
 public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, int p_offset);
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset);
 	virtual FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file);
 };
 

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -108,7 +108,7 @@ public:
 	_FORCE_INLINE_ bool is_disabled() const { return disabled; }
 
 	static PackedData *get_singleton() { return singleton; }
-	Error add_pack(const String &p_path, bool p_replace_files);
+	Error add_pack(const String &p_path, bool p_replace_files, int p_offset);
 
 	_FORCE_INLINE_ FileAccess *try_open_path(const String &p_path);
 	_FORCE_INLINE_ bool has_path(const String &p_path);
@@ -119,14 +119,14 @@ public:
 
 class PackSource {
 public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files) = 0;
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, int p_offset) = 0;
 	virtual FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file) = 0;
 	virtual ~PackSource() {}
 };
 
 class PackedSourcePCK : public PackSource {
 public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files);
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, int p_offset);
 	virtual FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file);
 };
 

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -150,7 +150,7 @@ unzFile ZipArchive::get_file_handle(String p_file) const {
 bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset = 0) {
 	//printf("opening zip pack %ls, %i, %i\n", p_name.c_str(), p_name.extension().nocasecmp_to("zip"), p_name.extension().nocasecmp_to("pcz"));
 	// load with offset feature only supported for PCK files
-	ERR_FAIL_COND_V_MSG(p_offset != 0, false, "Load with offset feature not supported for ZIP files.");
+	ERR_FAIL_COND_V_MSG(p_offset != 0, false, "Load with offset feature not supported for Zip files.");
 
 	if (p_path.get_extension().nocasecmp_to("zip") != 0 && p_path.get_extension().nocasecmp_to("pcz") != 0) {
 		return false;

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -149,7 +149,12 @@ unzFile ZipArchive::get_file_handle(String p_file) const {
 
 bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset = 0) {
 	//printf("opening zip pack %ls, %i, %i\n", p_name.c_str(), p_name.extension().nocasecmp_to("zip"), p_name.extension().nocasecmp_to("pcz"));
-	if (p_path.get_extension().nocasecmp_to("zip") != 0 && p_path.get_extension().nocasecmp_to("pcz") != 0) {
+    // load with offset feature only support for PCK files
+    if (p_offset != 0) {
+        return false;
+    }
+
+    if (p_path.get_extension().nocasecmp_to("zip") != 0 && p_path.get_extension().nocasecmp_to("pcz") != 0) {
 		return false;
 	}
 

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -147,7 +147,7 @@ unzFile ZipArchive::get_file_handle(String p_file) const {
 	return pkg;
 }
 
-bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, int p_offset = 0) {
+bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset = 0) {
 	//printf("opening zip pack %ls, %i, %i\n", p_name.c_str(), p_name.extension().nocasecmp_to("zip"), p_name.extension().nocasecmp_to("pcz"));
 	if (p_path.get_extension().nocasecmp_to("zip") != 0 && p_path.get_extension().nocasecmp_to("pcz") != 0) {
 		return false;

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -149,12 +149,12 @@ unzFile ZipArchive::get_file_handle(String p_file) const {
 
 bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset = 0) {
 	//printf("opening zip pack %ls, %i, %i\n", p_name.c_str(), p_name.extension().nocasecmp_to("zip"), p_name.extension().nocasecmp_to("pcz"));
-    // load with offset feature only supported for PCK files
-    if (p_offset != 0) {
-        return false;
-    }
+	// load with offset feature only supported for PCK files
+	if (p_offset != 0) {
+		return false;
+	}
 
-    if (p_path.get_extension().nocasecmp_to("zip") != 0 && p_path.get_extension().nocasecmp_to("pcz") != 0) {
+	if (p_path.get_extension().nocasecmp_to("zip") != 0 && p_path.get_extension().nocasecmp_to("pcz") != 0) {
 		return false;
 	}
 

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -149,7 +149,7 @@ unzFile ZipArchive::get_file_handle(String p_file) const {
 
 bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset = 0) {
 	//printf("opening zip pack %ls, %i, %i\n", p_name.c_str(), p_name.extension().nocasecmp_to("zip"), p_name.extension().nocasecmp_to("pcz"));
-    // load with offset feature only support for PCK files
+    // load with offset feature only supported for PCK files
     if (p_offset != 0) {
         return false;
     }

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -150,9 +150,7 @@ unzFile ZipArchive::get_file_handle(String p_file) const {
 bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset = 0) {
 	//printf("opening zip pack %ls, %i, %i\n", p_name.c_str(), p_name.extension().nocasecmp_to("zip"), p_name.extension().nocasecmp_to("pcz"));
 	// load with offset feature only supported for PCK files
-	if (p_offset != 0) {
-		return false;
-	}
+	ERR_FAIL_COND_V_MSG(p_offset != 0, false, "Load with offset feature not supported for ZIP files.");
 
 	if (p_path.get_extension().nocasecmp_to("zip") != 0 && p_path.get_extension().nocasecmp_to("pcz") != 0) {
 		return false;

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -147,7 +147,7 @@ unzFile ZipArchive::get_file_handle(String p_file) const {
 	return pkg;
 }
 
-bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files) {
+bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, int p_offset = 0) {
 	//printf("opening zip pack %ls, %i, %i\n", p_name.c_str(), p_name.extension().nocasecmp_to("zip"), p_name.extension().nocasecmp_to("pcz"));
 	if (p_path.get_extension().nocasecmp_to("zip") != 0 && p_path.get_extension().nocasecmp_to("pcz") != 0) {
 		return false;

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -69,7 +69,7 @@ public:
 
 	bool file_exists(String p_name) const;
 
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, int p_offset);
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset);
 	FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file);
 
 	static ZipArchive *get_singleton();

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -69,7 +69,7 @@ public:
 
 	bool file_exists(String p_name) const;
 
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files);
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, int p_offset);
 	FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file);
 
 	static ZipArchive *get_singleton();

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -957,8 +957,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("localize_path", "path"), &ProjectSettings::localize_path);
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
-	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"),
-    &ProjectSettings::_load_resource_pack, DEFVAL(true), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"), &ProjectSettings::_load_resource_pack, DEFVAL(true), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("property_can_revert", "name"), &ProjectSettings::property_can_revert);
 	ClassDB::bind_method(D_METHOD("property_get_revert", "name"), &ProjectSettings::property_get_revert);
 

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -256,12 +256,12 @@ void ProjectSettings::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
-bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files) {
+bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset) {
 	if (PackedData::get_singleton()->is_disabled()) {
 		return false;
 	}
 
-	bool ok = PackedData::get_singleton()->add_pack(p_pack, p_replace_files) == OK;
+	bool ok = PackedData::get_singleton()->add_pack(p_pack, p_replace_files, p_offset) == OK;
 
 	if (!ok) {
 		return false;
@@ -957,7 +957,8 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("localize_path", "path"), &ProjectSettings::localize_path);
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
-	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files"), &ProjectSettings::_load_resource_pack, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"),
+    &ProjectSettings::_load_resource_pack, DEFVAL(true), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("property_can_revert", "name"), &ProjectSettings::property_can_revert);
 	ClassDB::bind_method(D_METHOD("property_get_revert", "name"), &ProjectSettings::property_get_revert);
 

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -96,7 +96,7 @@ protected:
 
 	void _convert_to_last_version(int p_from_version);
 
-	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true);
+	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0);
 
 	void _add_property_info_bind(const Dictionary &p_info);
 


### PR DESCRIPTION
Added an optional int offset field for ```load_resource_pack()```, ```add_packs()``` and ```try_open_pack()``` in order to support .PCK file loading with offset. Need to update corresponding Godot Docs when these changes are merged.
With this PR, developers can load PCK with offsets using this syntax: 
<img width="750" alt="Screen Shot 2020-07-13 at 4 28 00 PM" src="https://user-images.githubusercontent.com/14120761/87355347-d965a300-c525-11ea-95e2-8293ca57034d.png">
<img width="569" alt="Screen Shot 2020-07-13 at 4 27 30 PM" src="https://user-images.githubusercontent.com/14120761/87355335-d5398580-c525-11ea-8d2b-d8441bb3f626.png">
